### PR TITLE
Add defaults to the quality setting and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Usage and example formatting below, or see the [tests](https://github.com/mapbox
 
 `format` (optional): `png` or `jpeg`, default is `png`.
 
-`quality` (optional): when used with `jpeg` format, accepts 1-100 and defaults to 80. when used with `png` format, accepts 2-256 (# of colors to reduce the image to) and defaults to none.
+`quality` (optional): when used with `jpeg` format, accepts 1-100 and defaults to 85. when used with `png` format, accepts 2-256 (# of colors to reduce the image to) and defaults to 256.
 
 `tileSize` (optional, defaults to `256`): Specifies input size of tiles used in `getTile` function.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# v3.2.0
+* Add defaults for the quality to support lib-mapnik 3.1.x
+
 # v3.1.1
 * Fixes tile size calculation
 * Bump dependencies

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function abaculus(arg, callback) {
         bbox = arg.bbox || null,
         getTile = arg.getTile || null,
         format = arg.format || 'png',
-        quality = arg.quality || null,
+        quality = arg.quality || ( format === 'png' ? 256 : 85 ),
         limit = arg.limit || 19008,
         tileSize = arg.tileSize || 256;
 


### PR DESCRIPTION
This will add support for lib-mapnik > 3.1 where an integer is expected for blend. The defaults are taken from lib-mapnik code.

I decided for a "bigger" version bump for adding that fundamental lib-mapnik support.